### PR TITLE
fastVoteR 0.0.3 update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     rush (>= 1.0.0),
     testthat (>= 3.0.0)
 Remotes:
-    bblodfon/fastVoteR@rm_data_table
+    bblodfon/fastVoteR
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,6 +48,8 @@ Suggests:
     rpart,
     rush (>= 1.0.0),
     testthat (>= 3.0.0)
+Remotes:
+    bblodfon/fastVoteR@rm_data_table
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     stabm
 Suggests:
     e1071,
-    fastVoteR,
+    fastVoteR (>= 0.0.3),
     genalg,
     mirai,
     mlr3learners,
@@ -48,8 +48,6 @@ Suggests:
     rpart,
     rush (>= 1.0.0),
     testthat (>= 3.0.0)
-Remotes:
-    bblodfon/fastVoteR
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 # mlr3fselect (development version)
 
 * refactor: Remove rush backward compatibility.
-* docs: add hEFS reference.
+* docs: Add hEFS reference.
+* compatibility: `fastVoteR` 0.0.3
+* feat: Add `$rm_zero_features()` method in `EnsembleFSResult` to remove result rows where no features were selected.
 
 # mlr3fselect 1.5.1
 

--- a/R/EnsembleFSResult.R
+++ b/R/EnsembleFSResult.R
@@ -195,7 +195,7 @@ EnsembleFSResult = R6Class(
         private$.result = private$.result[keep]
         private$.stability_global = NULL
         private$.stability_learner = NULL
-        print(sprintf("%s results with zero selected features have been removed.", n_removed))
+        lg$info(sprintf("%s results with zero selected features have been removed.", n_removed))
       }
 
       invisible(self)

--- a/R/EnsembleFSResult.R
+++ b/R/EnsembleFSResult.R
@@ -259,8 +259,8 @@ EnsembleFSResult = R6Class(
     #' i.e. it can be used to compare the feature rankings across different methods.
     #'
     #' We shuffle the input candidates/features so that we enforce random tie-breaking.
-    #' Users should set the same `seed` for consistent comparison between the different feature ranking methods
-    #' and for reproducibility.
+    #' Users should set the same `seed` for consistent comparison between the different
+    #' feature ranking methods and for reproducibility.
     #'
     #' @param method (`character(1)`)\cr
     #' The method to calculate the feature ranking. See [fastVoteR::rank_candidates()]
@@ -269,12 +269,14 @@ EnsembleFSResult = R6Class(
     #' @param use_weights (`logical(1)`)\cr
     #' The default value (`TRUE`) uses weights equal to the performance scores
     #' of each voter/model (or the inverse scores if the measure is minimized).
-    #' If `FALSE`, we treat all voters as equal and assign them all a weight equal to 1.
+    #' Note that the performance scores need to be non-negative for the weights
+    #' to be meaningful. If the scores can be negative, it is recommended to set
+    #' `use_weights = FALSE`, which treats all voters as equal and assigns them
+    #' the same weight equal to 1.
     #' @param committee_size (`integer(1)`)\cr
-    #' Number of top selected features in the output ranking.
-    #' This parameter can be used to speed-up methods that build a committee sequentially
-    #' (`"seq_pav"`), by requesting only the top N selected candidates/features
-    #' and not the complete feature ranking.
+    #' The number of top-ranked features to return.
+    #' This can speed up methods that build a committee sequentially (e.g., `"seq_pav"`)
+    #' by computing only the top N candidates rather than the full ranking.
     #' @param shuffle_features (`logical(1)`)\cr
     #' Whether to shuffle the task features randomly before computing the ranking.
     #' Shuffling ensures consistent random tie-breaking across methods and prevents
@@ -293,7 +295,6 @@ EnsembleFSResult = R6Class(
     #'   where the top feature receives a score of 1 and the lowest-ranked feature receives a score of 0.
     #'   This column is always included so that feature ranking methods that output only rankings
     #'   have also a feature-wise score.
-    #'
     feature_ranking = function(method = "av", use_weights = TRUE, committee_size = NULL, shuffle_features = TRUE) {
       requireNamespace("fastVoteR")
 
@@ -315,14 +316,16 @@ EnsembleFSResult = R6Class(
       }
 
       # get consensus feature ranking
-      res = fastVoteR::rank_candidates(
-        voters = voters,
-        candidates = candidates,
-        weights = weights,
-        committee_size = committee_size,
-        method = method,
-        borda_score = TRUE,
-        shuffle_candidates = shuffle_features
+      res = as.data.table(
+        fastVoteR::rank_candidates(
+          voters = voters,
+          candidates = candidates,
+          weights = weights,
+          committee_size = committee_size,
+          method = method,
+          borda_score = TRUE,
+          shuffle_candidates = shuffle_features
+        )
       )
 
       setnames(res, "candidate", "feature")

--- a/R/EnsembleFSResult.R
+++ b/R/EnsembleFSResult.R
@@ -153,6 +153,55 @@ EnsembleFSResult = R6Class(
     },
 
     #' @description
+    #' Removes rows from the ensemble feature selection result where no features were selected.
+    #'
+    #' If a benchmark result is stored, the corresponding resampling iterations are removed as well.
+    #' The stability measures are reset and need to be recalculated after this operation.
+    #'
+    #' This method modifies the object by reference.
+    #' To preserve the original state, explicitly `$clone()` the object beforehand.
+    #'
+    #' @return
+    #' Returns the object itself, but modified **by reference**.
+    rm_zero_features = function() {
+      keep = private$.result$n_features > 0L
+      n_removed = sum(!keep)
+
+      if (n_removed > 0L) {
+        if (!is.null(self$benchmark_result)) {
+          # filter the resample results of the benchmark result
+          resample_results = self$benchmark_result$resample_results$resample_result
+          filtered_resample_results = list()
+          keep_rows = which(keep)
+          row_start = 0L
+
+          for (rr in resample_results) {
+            row_end = row_start + rr$iters
+            iters = keep_rows[keep_rows > row_start & keep_rows <= row_end] - row_start
+            row_start = row_end
+
+            if (length(iters)) {
+              rr$filter(iters = iters)
+              filtered_resample_results = c(filtered_resample_results, list(rr))
+            }
+          }
+
+          self$benchmark_result = if (length(filtered_resample_results)) {
+            do.call(c, filtered_resample_results)
+          } else {
+            NULL
+          }
+        }
+        private$.result = private$.result[keep]
+        private$.stability_global = NULL
+        private$.stability_learner = NULL
+        print(sprintf("%s results with zero selected features have been removed.", n_removed))
+      }
+
+      invisible(self)
+    },
+
+    #' @description
     #' Use this function to change the active measure.
     #'
     #' @param which (`character(1)`)\cr

--- a/man/ensemble_fs_result.Rd
+++ b/man/ensemble_fs_result.Rd
@@ -310,13 +310,15 @@ Approval voting (\code{"av"}) is the default method.}
 \item{\code{use_weights}}{(\code{logical(1)})\cr
 The default value (\code{TRUE}) uses weights equal to the performance scores
 of each voter/model (or the inverse scores if the measure is minimized).
-If \code{FALSE}, we treat all voters as equal and assign them all a weight equal to 1.}
+Note that the performance scores need to be non-negative for the weights
+to be meaningful. If the scores can be negative, it is recommended to set
+\code{use_weights = FALSE}, which treats all voters as equal and assigns them
+the same weight equal to 1.}
 
 \item{\code{committee_size}}{(\code{integer(1)})\cr
-Number of top selected features in the output ranking.
-This parameter can be used to speed-up methods that build a committee sequentially
-(\code{"seq_pav"}), by requesting only the top N selected candidates/features
-and not the complete feature ranking.}
+The number of top-ranked features to return.
+This can speed up methods that build a committee sequentially (e.g., \code{"seq_pav"})
+by computing only the top N candidates rather than the full ranking.}
 
 \item{\code{shuffle_features}}{(\code{logical(1)})\cr
 Whether to shuffle the task features randomly before computing the ranking.
@@ -340,8 +342,8 @@ so we always include \strong{Borda's score}, which is method-agnostic,
 i.e. it can be used to compare the feature rankings across different methods.
 
 We shuffle the input candidates/features so that we enforce random tie-breaking.
-Users should set the same \code{seed} for consistent comparison between the different feature ranking methods
-and for reproducibility.
+Users should set the same \code{seed} for consistent comparison between the different
+feature ranking methods and for reproducibility.
 }
 
 \subsection{Returns}{

--- a/tests/testthat/test_embedded_ensemble_fselect.R
+++ b/tests/testthat/test_embedded_ensemble_fselect.R
@@ -62,6 +62,15 @@ test_that("embedded efs works", {
   feature_ranking = efsr$feature_ranking()
   expect_data_table(feature_ranking, nrows = length(task$feature_names))
   expect_equal(names(feature_ranking), c("feature", "score", "norm_score", "borda_score"))
+
+  # remove zero features (all rows with the featureless learner should be removed)
+  efsr_zero = efsr$clone(deep = TRUE)
+  suppressMessages(efsr_zero$rm_zero_features())
+  expect_data_table(efsr_zero$result, nrows = 5L)
+  expect_true(all(efsr_zero$result$n_features > 0L))
+  expect_equal(efsr_zero$n_learners, 1L)
+  expect_equal(efsr_zero$n_resamples, 5L)
+  expect_equal(efsr_zero$benchmark_result$n_resample_results, 1L)
 })
 
 test_that("combine embedded efs results", {

--- a/tests/testthat/test_embedded_ensemble_fselect.R
+++ b/tests/testthat/test_embedded_ensemble_fselect.R
@@ -65,7 +65,7 @@ test_that("embedded efs works", {
 
   # remove zero features (all rows with the featureless learner should be removed)
   efsr_zero = efsr$clone(deep = TRUE)
-  suppressMessages(efsr_zero$rm_zero_features())
+  efsr_zero$rm_zero_features()
   expect_data_table(efsr_zero$result, nrows = 5L)
   expect_true(all(efsr_zero$result$n_features > 0L))
   expect_equal(efsr_zero$n_learners, 1L)

--- a/tests/testthat/test_ensemble_fselect.R
+++ b/tests/testthat/test_ensemble_fselect.R
@@ -383,6 +383,27 @@ test_that("combining EnsembleFSResult objects", {
   expect_null(get_private(comb_all)$.inner_measure$id)
 })
 
+test_that("EnsembleFSResult can remove zero-feature results", {
+  result = data.table(
+    resampling_iteration = c(1L, 2L, 3L),
+    learner_id = c("lrn1", "lrn1", "lrn2"),
+    n_features = c(0L, 2L, 0L),
+    features = list(character(), c("V1", "V2"), character()),
+    classif.ce = c(0.5, 0.2, 0.4)
+  )
+  efsr = EnsembleFSResult$new(result = result, features = paste0("V", 1:2), measure = msr("classif.ce"))
+
+  suppressMessages(efsr$rm_zero_features())
+
+  expect_data_table(efsr$result, nrows = 1L)
+  expect_equal(efsr$result$resampling_iteration, 2L)
+  expect_equal(efsr$result$learner_id, "lrn1")
+  expect_equal(efsr$result$n_features, 2L)
+  expect_equal(efsr$result$features[[1L]], c("V1", "V2"))
+  expect_equal(efsr$n_learners, 1L)
+  expect_equal(efsr$n_resamples, 1L)
+})
+
 test_that("different callbacks can be set", {
   callback_test = callback_batch_fselect("mlr3fselect.test", on_eval_before_archive = function(callback, context) {
     context$aggregated_performance[, callback_active := context$instance$objective$learner$id == "classif.rpart"]

--- a/tests/testthat/test_ensemble_fselect.R
+++ b/tests/testthat/test_ensemble_fselect.R
@@ -393,8 +393,7 @@ test_that("EnsembleFSResult can remove zero-feature results", {
   )
   efsr = EnsembleFSResult$new(result = result, features = paste0("V", 1:2), measure = msr("classif.ce"))
 
-  suppressMessages(efsr$rm_zero_features())
-
+  efsr$rm_zero_features()
   expect_data_table(efsr$result, nrows = 1L)
   expect_equal(efsr$result$resampling_iteration, 2L)
   expect_equal(efsr$result$learner_id, "lrn1")


### PR DESCRIPTION
Main change was that I dropped the `data.table` dependency in `fastVoteR`, and I just convert the returned `data.frame` to a `data.table` in `mlr3fselect`, according to `mlr3` conventions