### PR TITLE
fix(rfecv): respect the direction of the measure

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3fselect (development version)
 
 * fix: `ArchiveAsyncFSelect` pushed results with the removed `rush::Rush$push_results()` method.
+* fix: `fs("rfecv")` ignored the direction of the measure and selected the feature set size with the *worst* mean performance for minimizing measures such as `msr("classif.ce")` or `msr("regr.mse")`. Feature selection results obtained with `fs("rfecv")` and a minimizing measure are invalid and should be recomputed (#167).
 
 # mlr3fselect 1.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # mlr3fselect (development version)
 
 * fix: `ArchiveAsyncFSelect` pushed results with the removed `rush::Rush$push_results()` method.
-* fix: `fs("rfecv")` ignored the direction of the measure and selected the feature set size with the *worst* mean performance for minimizing measures such as `msr("classif.ce")` or `msr("regr.mse")`. Feature selection results obtained with `fs("rfecv")` and a minimizing measure are invalid and should be recomputed (#167).
+* fix: `fs("rfecv")` ignored the direction of the measure and selected the feature set size with the worst mean performance for minimizing measures such as `msr("classif.ce")` or `msr("regr.mse")`.
+  Feature selection results obtained with `fs("rfecv")` and a minimizing measure are invalid and should be recomputed (#167).
 
 # mlr3fselect 1.6.0
 

--- a/R/FSelectorBatchRFECV.R
+++ b/R/FSelectorBatchRFECV.R
@@ -165,7 +165,8 @@ FSelectorBatchRFECV = R6Class(
 
       # average performance of feature numbers
       aggr = archive$data[, list("y" = mean(unlist(.SD))), by = "batch_nr", .SDcols = archive$cols_y]
-      best_batch = aggr[order(get("y"), decreasing = TRUE), head(.SD, 1)]$batch_nr
+      # the direction of the codomain determines whether the performance is minimized or maximized
+      best_batch = aggr[which_max(aggr[["y"]] * -archive$codomain$direction, ties_method = "first")]$batch_nr
       n_features = rowSums(archive$data[list(best_batch), , on = "batch_nr"][1, archive$cols_x, with = FALSE])
 
       # use full data set

--- a/tests/testthat/test_FSelectorRFECV.R
+++ b/tests/testthat/test_FSelectorRFECV.R
@@ -85,6 +85,53 @@ test_that("learner without importance method throw an error", {
   )
 })
 
+test_that("optimal features are selected with a minimizing measure", {
+  LearnerRegrDebugImportance = R6Class(
+    "LearnerRegrDebugImportance",
+    inherit = LearnerRegrDebug,
+    public = list(
+      importance = function() {
+        c(x2 = 1.4, x1 = 0.8, x3 = 1.2, x4 = 1.1)
+      }
+    )
+  )
+
+  learner = LearnerRegrDebugImportance$new()
+  learner$properties = c(learner$properties, "importance")
+
+  # the three features x2, x3 and x4 have the lowest score
+  score_design = data.table(
+    score = c(2, 1, 4, 3),
+    features = list(
+      c("x1", "x2", "x3", "x4"),
+      c("x2", "x3", "x4"),
+      c("x2", "x3"),
+      "x2"
+    )
+  )
+
+  measure = msr("dummy", score_design = score_design, minimize = TRUE)
+
+  instance = fsi(
+    task = TEST_MAKE_TSK(),
+    learner = learner,
+    resampling = rsmp("cv", folds = 3),
+    measures = measure,
+    terminator = trm("none"),
+    store_models = TRUE
+  )
+
+  optimizer = fs("rfecv", n_features = 1, feature_number = 1)
+  optimizer$optimize(instance)
+  data = as.data.table(instance$archive)
+
+  # number of features in the final run
+  expect_feature_number(data[13, 1:4], n = 4)
+  expect_feature_number(data[14, 1:4], n = 3)
+
+  expect_equal(instance$result$features[[1]], c("x2", "x3", "x4"))
+})
+
 test_that("optimal features are selected", {
   LearnerRegrDebugImportance = R6Class(
     "LearnerRegrDebugImportance",


### PR DESCRIPTION
## Problem

`FSelectorBatchRFECV` determines the optimal number of features by aggregating the performance of each batch and taking the best one:

```r
aggr = archive$data[, list("y" = mean(unlist(.SD))), by = "batch_nr", .SDcols = archive$cols_y]
best_batch = aggr[order(get("y"), decreasing = TRUE), head(.SD, 1)]$batch_nr
```

`decreasing = TRUE` is hardcoded and `archive$codomain$direction` is never consulted, while `archive$data` holds the raw measure value. For every minimizing measure — which includes all mlr3 defaults, `msr("classif.ce")` and `msr("regr.mse")` — this selects the feature set size with the **worst** mean performance, and the final elimination run is then driven down to that size.

Reproduced on `tsk("sonar")` reduced to `V1`-`V8`, `lrn("classif.rpart")`, `rsmp("cv", folds = 3)`, `msr("classif.ce")`:

| batch | features | mean classif.ce |
|-------|----------|-----------------|
| 3     | 6        | 0.4038 (best)   |
| 7     | 2        | 0.4709          |
| 8     | 1        | 0.5094 (picked before this PR) |

Before: `instance$result$n_features` is 1. After: 6.

## Fix

Multiply the mean scores with the negated codomain direction before taking the maximum, mirroring `ArchiveBatchFSelect$best()`.

## Why the test suite missed it

Every rfecv test uses `msr("dummy")`, and `MeasureDummy` defaults to `minimize = FALSE` — the suite exercised only the direction where the bug is invisible. This PR adds a rfecv test with `minimize = TRUE` that fails on `main` (it selects 2 instead of 3 features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)