### PR TITLE
fix(rfe): write importance to the whole batch when recursive is FALSE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3fselect (development version)
 
 * fix: `ArchiveAsyncFSelect` pushed results with the removed `rush::Rush$push_results()` method.
+* fix: `fs("rfecv", recursive = FALSE)` failed with an internal `data.table` error because the importance scores of all resampling iterations were written to a single archive row (#168).
 
 # mlr3fselect 1.6.0
 

--- a/R/FSelectorBatchRFE.R
+++ b/R/FSelectorBatchRFE.R
@@ -277,7 +277,12 @@ rfe_workhorse = function(inst, subsets, recursive, aggregation = raw_importance,
       archive$data[list(archive$n_batch), "importance" := importances, on = "batch_nr"]
     } else {
       # log importance to archive
-      set(archive$data, archive$n_evals, "importance", map(importances, function(x) x[seq(j)]))
+      # the batch holds one row per fold, so the truncated importance of each fold is assigned to the whole batch
+      archive$data[
+        list(archive$n_batch),
+        "importance" := map(importances, function(x) x[seq(j)]),
+        on = "batch_nr"
+      ]
     }
   }
   if (folds > 1) {

--- a/tests/testthat/test_FSelectorRFECV.R
+++ b/tests/testthat/test_FSelectorRFECV.R
@@ -68,6 +68,31 @@ test_that("default parameters work", {
   })
 })
 
+test_that("recursive parameter works", {
+  instance = fsi(
+    task = TEST_MAKE_TSK(),
+    learner = lrn("regr.rpart"),
+    resampling = rsmp("cv", folds = 3),
+    measures = msr("dummy"),
+    terminator = trm("none"),
+    store_models = TRUE
+  )
+
+  optimizer = fs("rfecv", recursive = FALSE, n_features = 1, feature_number = 1)
+  optimizer$optimize(instance)
+  data = instance$archive$data
+
+  # the importance of the first batch is reused and truncated in the following batches
+  walk(seq(3), function(i) {
+    importances = data[list(i), importance, on = "iteration"]
+    walk(seq(2, length(importances)), function(j) {
+      expect_equal(importances[[j]], importances[[1]][seq(length(importances) + 1 - j)])
+    })
+  })
+
+  pwalk(data, function(x1, x2, x3, x4, importance, ...) expect_equal(x1 + x2 + x3 + x4, length(importance)))
+})
+
 test_that("learner without importance method throw an error", {
   learner = lrn("classif.rpart")
   learner$properties = setdiff(learner$properties, "importance")


### PR DESCRIPTION
## Problem

`fs("rfecv", recursive = FALSE)` — a documented control parameter of `mlr_fselectors_rfecv` — crashes:

```r
fselect(fs("rfecv", recursive = FALSE, n_features = 2, feature_number = 1), task,
        lrn("classif.rpart"), rsmp("cv", folds = 3), msr("classif.ce"), store_models = TRUE)
#> Error: Internal error in memrecycle: recycle length error not caught earlier.
#>        slen=3 len=1. Please report to the data.table issues tracker.
```

The non-recursive branch of `rfe_workhorse()` writes the importance scores to a single archive row:

```r
set(archive$data, archive$n_evals, "importance", map(importances, function(x) x[seq(j)]))
```

RFECV calls the workhorse with `folds = resampling$iters`, so `importances` holds one vector per resampling iteration while `archive$n_evals` is a single row index. The recursive branch directly above already handles this correctly with an `on = "batch_nr"` join.

The error message asks the user to report the bug to data.table, i.e. against the wrong project.

## Fix

Mirror the recursive branch and assign the truncated importance vectors to the whole batch.

## Test

Adds a `recursive = FALSE` test to `test_FSelectorRFECV.R` that asserts the first batch's importance is reused and truncated per fold, and that each row's importance vector matches its number of selected features. It errors on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)