### PR TITLE
fix(rfe): read importance from the benchmark result of the objective

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3fselect (development version)
 
 * fix: `ArchiveAsyncFSelect` pushed results with the removed `rush::Rush$push_results()` method.
+* fix: `fs("rfe")` and `fs("rfecv")` failed with an internal `data.table` error when `store_benchmark_result = FALSE` was set because the importance scores were read from the benchmark result of the archive (#169).
 
 # mlr3fselect 1.6.0
 

--- a/R/FSelectorBatchRFE.R
+++ b/R/FSelectorBatchRFE.R
@@ -210,6 +210,17 @@ rank_importance = function(learners, features) {
   sort(set_names(pmap_dbl(ranked_importances, function(...) mean(c(...))), names(importances[[1]])), decreasing = TRUE)
 }
 
+# Calculates the importance scores of the feature subsets evaluated in the last batch.
+# The benchmark result of the objective is used instead of the one of the archive because it holds the models of the
+# last batch even if `store_benchmark_result` is `FALSE`.
+batch_importances = function(inst, aggregation) {
+  benchmark_result = get_private(inst$objective)$.benchmark_result
+  map(benchmark_result$uhashes, function(uhash) {
+    rr = benchmark_result$resample_result(uhash = uhash)
+    aggregation(rr$learners, rr$task$feature_names)
+  })
+}
+
 # Returns the sizes of the feature subsets
 rfe_subsets = function(n, n_features, feature_number, subset_sizes, feature_fraction) {
   subsets = if (!is.null(feature_number)) {
@@ -240,11 +251,7 @@ rfe_workhorse = function(inst, subsets, recursive, aggregation = raw_importance,
   inst$eval_batch(states)
 
   # Calculate the variable importance on the full feature set
-  uhashes = archive$data[list(archive$n_batch), "uhash", on = "batch_nr"][[1]]
-  importances = map(uhashes, function(uhash) {
-    rr = archive$benchmark_result$resample_result(uhash = uhash)
-    aggregation(rr$learners, rr$task$feature_names)
-  })
+  importances = batch_importances(inst, aggregation)
 
   # discard models if requested by the user
   if (!inst$objective$store_models) {
@@ -267,11 +274,7 @@ rfe_workhorse = function(inst, subsets, recursive, aggregation = raw_importance,
 
     if (recursive) {
       # recalculate the variable importance on the reduced feature subset
-      uhashes = archive$data[list(archive$n_batch), "uhash", on = "batch_nr"][[1]]
-      importances = map(uhashes, function(uhash) {
-        rr = archive$benchmark_result$resample_result(uhash = uhash)
-        aggregation(rr$learners, rr$task$feature_names)
-      })
+      importances = batch_importances(inst, aggregation)
 
       # log importance to archive
       archive$data[list(archive$n_batch), "importance" := importances, on = "batch_nr"]

--- a/tests/testthat/test_FSelectorRFE.R
+++ b/tests/testthat/test_FSelectorRFE.R
@@ -319,3 +319,23 @@ test_that("optimal features are selected with mean", {
 
   expect_equal(instance$result$features[[1]], c("x2", "x3", "x4"))
 })
+
+test_that("rfe works without storing the benchmark result", {
+  instance = fsi(
+    task = TEST_MAKE_TSK(),
+    learner = lrn("regr.rpart"),
+    resampling = rsmp("cv", folds = 3),
+    measures = msr("dummy"),
+    terminator = trm("none"),
+    store_benchmark_result = FALSE
+  )
+
+  optimizer = fs("rfe", n_features = 1, feature_number = 1)
+  optimizer$optimize(instance)
+  data = instance$archive$data
+
+  expect_names(names(data), disjunct.from = "uhash")
+  expect_feature_number(data[batch_nr == 1, 1:4], n = 4)
+  expect_feature_number(data[batch_nr == 4, 1:4], n = 1)
+  pwalk(data, function(x1, x2, x3, x4, importance, ...) expect_equal(x1 + x2 + x3 + x4, length(importance)))
+})

--- a/tests/testthat/test_FSelectorRFECV.R
+++ b/tests/testthat/test_FSelectorRFECV.R
@@ -150,3 +150,22 @@ test_that("optimal features are selected", {
 
   expect_equal(instance$result$features[[1]], c("x2", "x3", "x4"))
 })
+
+test_that("rfecv works without storing the benchmark result", {
+  instance = fsi(
+    task = TEST_MAKE_TSK(),
+    learner = lrn("regr.rpart"),
+    resampling = rsmp("cv", folds = 3),
+    measures = msr("dummy"),
+    terminator = trm("none"),
+    store_benchmark_result = FALSE
+  )
+
+  optimizer = fs("rfecv", n_features = 1, feature_number = 1)
+  optimizer$optimize(instance)
+  data = instance$archive$data
+
+  expect_names(names(data), disjunct.from = "uhash")
+  expect_names(names(data), must.include = c("importance", "iteration"))
+  pwalk(data, function(x1, x2, x3, x4, importance, ...) expect_equal(x1 + x2 + x3 + x4, length(importance)))
+})


### PR DESCRIPTION
## Problem

```r
fselect(fs("rfe", n_features = 2), task, lrn("classif.rpart"), rsmp("holdout"),
        msr("classif.ce"), store_benchmark_result = FALSE)
#> Error: Internal error in [.data.table: column(s) not found: uhash.
#>        Please report to the data.table issues tracker.
```

`rfe_workhorse()` resolved the models of the last batch through the archive:

```r
uhashes = archive$data[list(archive$n_batch), "uhash", on = "batch_nr"][[1]]
importances = map(uhashes, function(uhash) {
  rr = archive$benchmark_result$resample_result(uhash = uhash)
  aggregation(rr$learners, rr$task$feature_names)
})
```

The `uhash` column and the archive's benchmark result only exist when `store_benchmark_result = TRUE`. The `"requires_model"` property forces `store_models` but nothing forces `store_benchmark_result`, so both `fs("rfe")` and `fs("rfecv")` abort — again with a message that asks the user to report the bug to data.table.

## Fix

`ObjectiveFSelectBatch` keeps the benchmark result of the *current* batch in `private$.benchmark_result` regardless of `store_benchmark_result`, and `.model_required` already forces `store_models = TRUE` for that internal benchmark. Read the importance scores from there via a new `batch_importances()` helper.

This keeps the memory guarantee the user asked for — only the current batch is held, exactly as before — and drops the dependency on the `uhash` column entirely. Forcing `store_benchmark_result = TRUE` instead would silently retain the full benchmark result of every batch.

## Tests

Adds `store_benchmark_result = FALSE` tests for rfe and rfecv, both of which error on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)