### PR TITLE
fix(extract_inner_fselect_results): copy the result before adding columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3fselect (development version)
 
 * fix: `ArchiveAsyncFSelect` pushed results with the removed `rush::Rush$push_results()` method.
+* fix: `extract_inner_fselect_results()` added the `iteration` and `fselect_instance` columns to the result of the inner `FSelectInstance` by reference, which created a circular reference between the instance and its own result (#172).
 
 # mlr3fselect 1.6.0
 

--- a/R/extract_inner_fselect_results.R
+++ b/R/extract_inner_fselect_results.R
@@ -63,7 +63,8 @@ extract_inner_fselect_results.ResampleResult = function(x, fselect_instance = FA
     return(data.table())
   }
   tab = imap_dtr(rr$learners, function(learner, i) {
-    data = setalloccol(learner$fselect_result)
+    # copy the result, otherwise the columns below are added to the result of the instance
+    data = copy(learner$fselect_result)
     set(data, j = "iteration", value = i)
     if (fselect_instance) {
       set(data, j = "fselect_instance", value = list(learner$fselect_instance))

--- a/tests/testthat/test_extract_inner_fselect_result.R
+++ b/tests/testthat/test_extract_inner_fselect_result.R
@@ -377,3 +377,27 @@ test_that("extract_inner_fselect_results function works with benchmark and retur
   )
   expect_equal(unique(ibmr$experiment), c(1, 2))
 })
+
+test_that("extract_inner_fselect_results does not modify the fselect result", {
+  rr = fselect_nested(
+    fs("random_search"),
+    tsk("iris"),
+    lrn("classif.rpart"),
+    rsmp("holdout"),
+    rsmp("cv", folds = 2),
+    msr("classif.ce"),
+    term_evals = 4
+  )
+
+  columns = names(rr$learners[[1]]$fselect_result)
+
+  extract_inner_fselect_results(rr)
+  expect_named(rr$learners[[1]]$fselect_result, columns)
+
+  extract_inner_fselect_results(rr, fselect_instance = TRUE)
+  expect_named(rr$learners[[1]]$fselect_result, columns)
+
+  # the instance is not added again when it is not requested
+  irr = extract_inner_fselect_results(rr)
+  expect_names(names(irr), disjunct.from = "fselect_instance")
+})


### PR DESCRIPTION
## Problem

```r
data = setalloccol(learner$fselect_result)   # NOT a copy
set(data, j = "iteration", value = i)
if (fselect_instance) set(data, j = "fselect_instance", value = list(learner$fselect_instance))
```

`setalloccol()` over-allocates in place; it does not copy. Both `set()` calls write into the `FSelectInstance`'s own `private$.result`.

```
result cols BEFORE: V1, V2, V3, V4, features, n_features, classif.ce
result cols AFTER : ..., classif.ce, iteration
result cols AFTER2: ..., classif.ce, iteration, fselect_instance
instance column leaks when asked not to: TRUE
circular ref (result$fselect_instance[[1]] is the instance): TRUE
```

Three consequences:

1. **Not idempotent.** After one call with `fselect_instance = TRUE`, a later call with `fselect_instance = FALSE` still returns the instance column — it is baked into the source table.
2. **Circular reference.** `instance$result$fselect_instance[[1]]` *is* the instance. Serializing the `ResampleResult` (`saveRDS`, parallel workers, `mlr3batchmark`) then walks a cycle and duplicates the whole archive.
3. A read-only extractor silently changes what `learner$fselect_result` returns for the rest of the session.

## Fix

`data = copy(learner$fselect_result)`. `setalloccol()` bought nothing here — the table is `rbindlist`ed right after.

`extract_inner_fselect_archives()` is not affected; it goes through `as.data.table(learner$archive)`, which already copies.

## Test

New test asserting that the column names of `learner$fselect_result` are unchanged after both extractor calls, and that the instance column does not leak into a later `fselect_instance = FALSE` call. It fails on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)