### PR TITLE
fix(one_se_rule): handle small archives and keep n_features an integer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3fselect (development version)
 
 * fix: `ArchiveAsyncFSelect` pushed results with the removed `rush::Rush$push_results()` method.
+* fix: The `mlr3fselect.one_se_rule` callback errored on archives with a single evaluation or with missing scores, and wrote the `n_features` column as a list column instead of an integer column (#174).
 
 # mlr3fselect 1.6.0
 

--- a/R/mlr_callbacks.R
+++ b/R/mlr_callbacks.R
@@ -166,11 +166,13 @@ load_callback_one_se_rule = function() {
     on_optimization_end = function(callback, context) {
       archive = context$instance$archive
       data = as.data.table(archive)
-      data[, "n_features" := map(get("features"), length)]
+      data[, "n_features" := lengths(get("features"))]
 
       # standard error
+      # `sd()` is `NA` for a single evaluation, in this case the smallest feature set is selected
       y = data[[archive$cols_y]]
-      se = sd(y) / sqrt(length(y))
+      n = sum(!is.na(y))
+      se = if (n < 2L) 0 else sd(y, na.rm = TRUE) / sqrt(n)
 
       columns_to_keep = setdiff(names(context$instance$result), "x_domain")
       if (se == 0) {
@@ -179,9 +181,10 @@ load_callback_one_se_rule = function() {
           data[, columns_to_keep, with = FALSE][which.min(n_features)]
       } else {
         # select smallest future set within one standard error of the best
+        # `which()` drops feature sets without a score
         best_y = context$instance$result_y
         context$instance$.__enclos_env__$private$.result =
-          data[y > best_y - se & y < best_y + se, columns_to_keep, with = FALSE][which.min(n_features)]
+          data[which(y > best_y - se & y < best_y + se), columns_to_keep, with = FALSE][which.min(n_features)]
       }
     }
   )

--- a/tests/testthat/test_mlr_callbacks.R
+++ b/tests/testthat/test_mlr_callbacks.R
@@ -52,6 +52,25 @@ test_that("one_se_rule callback works", {
   )
 
   expect_equal(instance$result_feature_set, c("x1", "x2", "x3"))
+  # the number of features is a scalar and not a list column
+  expect_integer(instance$result$n_features, len = 1)
+})
+
+test_that("one_se_rule callback works with a single evaluation", {
+  instance = fselect(
+    fselector = fs("random_search", batch_size = 1),
+    task = TEST_MAKE_TSK(),
+    learner = lrn("regr.rpart"),
+    resampling = rsmp("cv", folds = 3),
+    measures = msr("dummy"),
+    term_evals = 1,
+    callbacks = clbk("mlr3fselect.one_se_rule")
+  )
+
+  # the standard error of a single evaluation is `NA`
+  expect_data_table(instance$archive$data, nrows = 1)
+  expect_data_table(instance$result, nrows = 1)
+  expect_equal(instance$result$features[[1]], as.data.table(instance$archive)$features[[1]])
 })
 
 test_that("internal tuning callback works", {


### PR DESCRIPTION
## Problem 1 — crash on small archives

```r
y  = data[[archive$cols_y]]
se = sd(y) / sqrt(length(y))
if (se == 0) {
```

`sd()` of a length-one vector is `NA`:

```r
fselect(..., term_evals = 1, callbacks = clbk("mlr3fselect.one_se_rule"))
#> Error in if (se == 0) { : missing value where TRUE/FALSE needed
```

The same crash occurs for any `NA` in `y`.

**Fix:** treat fewer than two scores as no spread (select the smallest feature set), compute `sd(y, na.rm = TRUE)`, and wrap the window filter in `which()` so feature sets without a score are dropped instead of producing `NA` rows.

## Problem 2 — type corruption

```r
data[, "n_features" := map(get("features"), length)]
```

writes a **list** column, and it goes straight into `private$.result`. With the callback active `instance$result$n_features` is a `<list>`; without it the same field is an `<int>`. Anything doing arithmetic on `fselect_result$n_features` downstream breaks.

**Fix:** `lengths()`.

## Not addressed here — the definition of the standard error

The review this PR comes from also questions the statistics: the one-standard-error rule of Kuhn & Johnson (the cited source) uses the standard error across the *resampling folds of the best model*, whereas this callback uses the standard deviation across *all evaluated feature sets*. That measures how much the search space varies, not how uncertain the best estimate is — with a wide search the window becomes so large that the rule degenerates to "return the smallest feature set evaluated".

Changing it would alter the results of every existing use of this callback and needs a decision from the maintainer, so this PR deliberately leaves the definition alone and only fixes the crash and the column type. Happy to follow up if you want the fold-based standard error.

## Tests

* New test for a single-evaluation archive; it errors on `main`.
* The existing `one_se_rule` test now also asserts that `n_features` is an integer scalar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)