### PR TITLE
fix(async): honor the always_included column role

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3fselect (development version)
 
 * fix: `ArchiveAsyncFSelect` pushed results with the removed `rush::Rush$push_results()` method.
+* fix: The asynchronous feature selection ignored the `always_included` column role. Columns with this role were excluded from the models instead of being added to every feature subset (#175).
 
 # mlr3fselect 1.6.0
 

--- a/R/ObjectiveFSelectAsync.R
+++ b/R/ObjectiveFSelectAsync.R
@@ -22,14 +22,19 @@ ObjectiveFSelectAsync = R6Class(
     .eval = function(xs, resampling) {
       lg$debug("Evaluating feature subset %s", as_short_string(xs))
 
-      # restore features
+      # restore features and always included features
+      # the task is not cloned, so the column roles must be restored after the evaluation
       all_features = self$task$feature_names
-      on.exit(self$task$set_col_roles(all_features, "feature"))
+      always_included = self$task$col_roles$always_included
+      on.exit({
+        self$task$set_col_roles(always_included, "always_included")
+        self$task$set_col_roles(all_features, "feature")
+      })
 
       # select features
       private$.xs = xs
       call_back("on_eval_after_xs", self$callbacks, self$context)
-      self$task$select(names(private$.xs)[as.logical(private$.xs)])
+      select_features(self$task, names(private$.xs)[as.logical(private$.xs)])
 
       lg$debug("Resampling feature subset")
 

--- a/R/ObjectiveFSelectBatch.R
+++ b/R/ObjectiveFSelectBatch.R
@@ -63,11 +63,7 @@ ObjectiveFSelectBatch = R6Class(
 
       tasks = map(private$.xss, function(x) {
         state = self$task$feature_names[unlist(x)]
-        task = self$task$clone()
-        always_included = task$col_roles$always_included
-        task$set_col_roles(always_included, "feature")
-        task$select(c(state, always_included))
-        task
+        select_features(self$task$clone(), state)
       })
 
       # benchmark feature subsets

--- a/R/helper.R
+++ b/R/helper.R
@@ -18,6 +18,17 @@ measures_to_codomain = function(measures) {
   Codomain$new(domains)
 }
 
+# Restricts the task to the selected features and the features with the `always_included` column role.
+# The always included columns must be converted to features because a learner is only trained on the columns with the
+# `feature` column role.
+# The task is changed by reference.
+select_features = function(task, features) {
+  always_included = task$col_roles$always_included
+  task$set_col_roles(always_included, "feature")
+  task$select(c(features, always_included))
+  task
+}
+
 extract_runtime = function(resample_result) {
   runtimes = map_dbl(
     get_private(resample_result)$.data$learner_states(get_private(resample_result)$.view),

--- a/tests/testthat/test_FSelectInstanceAsyncSingleCrit.R
+++ b/tests/testthat/test_FSelectInstanceAsyncSingleCrit.R
@@ -161,3 +161,40 @@ test_that("saving the models with FSelectInstanceAsyncSingleCrit works", {
 
 #   fselector$optimize(instance)
 # })
+
+test_that("always include variable works", {
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  task = tsk("diabetes")
+  task$set_col_roles("glucose", "always_included")
+
+  instance = fsi_async(
+    task = task,
+    learner = lrn("classif.rpart"),
+    resampling = rsmp("cv", folds = 3),
+    measures = msr("classif.ce"),
+    terminator = trm("evals", n_evals = 5),
+    store_benchmark_result = TRUE,
+    store_models = TRUE,
+    rush = rush
+  )
+
+  fselector = fs("async_random_search")
+  fselector$optimize(instance)
+
+  expect_names(instance$archive$cols_x, disjunct.from = "glucose")
+  expect_names(names(instance$archive$data), disjunct.from = "glucose")
+  walk(instance$archive$finished_data$resample_result, function(rr) {
+    expect_names(
+      names(rr$learners[[1]]$state$data_prototype) %??% rr$learners[[1]]$state$feature_names,
+      must.include = "glucose"
+    )
+  })
+
+  # the column role is restored after the evaluation
+  expect_equal(instance$objective$task$col_roles$always_included, "glucose")
+})


### PR DESCRIPTION
## Problem

The batch objective honors the column role that this package registers in `zzz.R`:

```r
always_included = task$col_roles$always_included
task$set_col_roles(always_included, "feature")
task$select(c(state, always_included))
```

The async objective just does `self$task$select(names(private$.xs)[as.logical(private$.xs)])`. `grep -rn always_included R/` on `main` only hits `ObjectiveFSelectBatch.R` and `zzz.R`.

Because a learner is trained on the columns with the `feature` role and `always_included` columns do not have it, the async path does not merely fail to force the feature in — it **excludes it entirely**, the exact opposite of the requested semantics.

Reproduced with `tsk("sonar")` reduced to `V1`-`V4` and `task$set_col_roles("V1", "always_included")`, reading the features back off `rpart`'s `model$terms`:

```
=== BATCH (fs("random_search")) ===       === ASYNC (fs("async_random_search")) ===
  eval 1 trained on: V3,V1                  eval 1 trained on: V3
  eval 2 trained on: V2,V3,V4,V1            eval 2 trained on: V2,V4
  eval 3 trained on: V2,V3,V4,V1            eval 3 trained on: V3,V2,V4
```

Same task, same column role, silently different results.

## Fix

Hoist the column role handling into a shared `select_features()` helper in `R/helper.R` and call it from both objectives. The async objective does not clone the task, so `on.exit()` now restores the `always_included` role in addition to the `feature` role.

## Test

Adds the async equivalent of the existing batch test (`test_FSelectInstanceSingleCrit.R`): `glucose` is set to `always_included`, and the test asserts it is absent from the search space and the archive but present in every trained model, plus that the column role survives the run.

Note for reviewers reproducing locally: the mirai daemons load the **installed** mlr3fselect, not the `load_all()` version, so this test only exercises the fix after `R CMD INSTALL`. With the old code it produces 5 failures; with the fix `test_FSelectInstanceAsyncSingleCrit` is green (144 assertions), as are `test_ObjectiveFSelect*` (331) and the batch `test_FSelectInstanceSingleCrit` (224).

🤖 Generated with [Claude Code](https://claude.com/claude-code)