### PR TITLE
fix(shadow_variable_search): restore the instance state with on.exit()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mlr3fselect (development version)
 
 * fix: `ArchiveAsyncFSelect` pushed results with the removed `rush::Rush$push_results()` method.
+* fix: `fs("shadow_variable_search")` left the shadow variables in the task, domain and search space of the instance when the feature selection was aborted because the first selected feature was a shadow variable (#183).
 * fix: The `mlr3fselect.svm_rfe` callback accepted support vector machines without a `type` or `kernel` setting, although only `type = "C-classification"` and `kernel = "linear"` are supported. The callback now also errors on multi-class tasks for which the importance scores are not defined (#173).
 * fix: The asynchronous feature selection ignored the `always_included` column role. Columns with this role were excluded from the models instead of being added to every feature subset (#175).
 * fix: The `mlr3fselect.one_se_rule` callback errored on archives with a single evaluation or with missing scores, and wrote the `n_features` column as a list column instead of an integer column (#174).

--- a/R/FSelectorBatchShadowVariableSearch.R
+++ b/R/FSelectorBatchShadowVariableSearch.R
@@ -128,32 +128,27 @@ FSelectorBatchShadowVariableSearch = R6Class(
       inst$eval_batch(states)
 
       repeat {
-        ({
-          res = archive$best(batch = archive$n_batch)[, feature_names, with = FALSE]
+        res = archive$best(batch = archive$n_batch)[, feature_names, with = FALSE]
 
-          # check if any shadow variable was selected
-          if (any(as.logical(res[, shadow_variables, with = FALSE]))) {
-            # stop if the first selected feature is a shadow variable
-            if (archive$n_batch == 1) {
-              stop("The first selected feature is a shadow variable.")
-            }
-
-            # remove last batch with selected shadow variable from archive
-            archive = inst$archive
-            archive$data = archive$data[get("batch_nr") != archive$n_batch, ]
-            break
+        # check if any shadow variable was selected
+        if (any(as.logical(res[, shadow_variables, with = FALSE]))) {
+          # stop if the first selected feature is a shadow variable
+          if (archive$n_batch == 1) {
+            stop("The first selected feature is a shadow variable.")
           }
 
-          best_state = as.logical(res)
-          states = map_dtr(seq_along(best_state)[!best_state], function(i) {
-            if (!best_state[i]) {
-              new_state = best_state
-              new_state[i] = TRUE
-              set_names(as.list(new_state), feature_names)
-            }
-          })
-          inst$eval_batch(states)
+          # remove last batch with selected shadow variable from archive
+          archive$data = archive$data[get("batch_nr") != archive$n_batch, ]
+          break
+        }
+
+        best_state = as.logical(res)
+        states = map_dtr(seq_along(best_state)[!best_state], function(i) {
+          new_state = best_state
+          new_state[i] = TRUE
+          set_names(as.list(new_state), feature_names)
         })
+        inst$eval_batch(states)
       }
     }
   )

--- a/R/FSelectorBatchShadowVariableSearch.R
+++ b/R/FSelectorBatchShadowVariableSearch.R
@@ -90,10 +90,17 @@ FSelectorBatchShadowVariableSearch = R6Class(
 
   private = list(
     .optimize = function(inst) {
-      # save initial state
+      # save the initial state on the instance and restore it when the optimization ends
+      # on.exit() also restores the state when the optimization is aborted with an error
       task = inst$objective$task
-      private$.task = suppressWarnings(task$clone(deep = TRUE))
-      private$.domain = inst$objective$domain$clone()
+      original_task = task$clone(deep = TRUE)
+      original_domain = inst$objective$domain$clone()
+      on.exit({
+        inst$objective$task = original_task
+        inst$objective$domain = original_domain
+        inst$archive$search_space = original_domain
+        inst$search_space = original_domain
+      })
 
       # add shadow variables to task
       data = map_dtc(task$data(cols = task$feature_names), shuffle)
@@ -148,21 +155,7 @@ FSelectorBatchShadowVariableSearch = R6Class(
           inst$eval_batch(states)
         })
       }
-    },
-
-    .assign_result = function(inst) {
-      # restore task and domain without shadow variables
-      inst$objective$task = private$.task
-      inst$objective$domain = private$.domain
-      inst$archive$search_space = private$.domain
-      inst$search_space = private$.domain
-
-      assign_result_default(inst)
-    },
-
-    .task = NULL,
-
-    .domain = NULL
+    }
   )
 )
 

--- a/tests/testthat/test_FSelectorShadowVariableSearch.R
+++ b/tests/testthat/test_FSelectorShadowVariableSearch.R
@@ -69,3 +69,17 @@ test_that("search is terminated by terminator works", {
   # check that task is restored
   suppressWarnings(expect_equal(instance$objective$task, task))
 })
+
+test_that("state is restored when the optimization is aborted", {
+  score_design = data.table(score = 1, features = "permuted__x1")
+  instance = TEST_MAKE_INST_1D(measure = msr("dummy", score_design = score_design), terminator = trm("none"))
+  task = instance$objective$task$clone()
+  domain = instance$objective$domain$clone()
+  fselector = fs("shadow_variable_search")
+
+  expect_error(fselector$optimize(instance), regexp = "The first selected feature is a shadow variable.")
+
+  expect_equal(instance$search_space, domain)
+  expect_equal(instance$objective$domain, domain)
+  expect_equal(instance$objective$task$feature_names, task$feature_names)
+})


### PR DESCRIPTION
`.optimize()` mutates `inst$objective$task` (`task$cbind(data)`), the domain and the search space; `.assign_result()` restored them. But when `.optimize()` throws — the documented `"The first selected feature is a shadow variable."` abort — `.assign_result()` never runs, and the instance is left permanently corrupted:

```
objective task features: V1..V5, permuted__V1..permuted__V5
```

Changes:

* The saved originals move from the `FSelector` (`private$.task`, `private$.domain`) into the `.optimize()` call frame, so no state is kept on the optimizer between runs.
* Restoration happens in `on.exit()`, so it also runs when the optimization aborts. `optimize_batch_default()` calls `.assign_result()` after `.optimize()` returns, so the ordering is unchanged for the normal path.
* `.assign_result()` did nothing beyond the restoration plus `assign_result_default(inst)`, which is exactly the base class implementation, so the override is removed.
* `suppressWarnings(task$clone(deep = TRUE))` suppressed an unnamed condition with no comment. `Task$clone(deep = TRUE)` signals no warning in the supported mlr3 versions (`mlr3 (>= 1.0.1)`), so the wrapper is dropped.

A test asserts that the task, domain and search space are restored after the abort; it fails on the previous implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)