### PR TITLE
fix(AutoFSelector): apply the predict type to the final model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * fix: `as.data.table()` on an `EnsembleFSResult` accepts the documented `benchmark_result` argument now to omit the task, learner and resampling columns (#190).
 * fix: The `$print()` methods of `ArchiveBatchFSelect`, `ArchiveAsyncFSelect`, `ArchiveAsyncFSelectFrozen`, `AutoFSelector` and `FSelector` errored with `unused argument` when arguments such as `digits` were passed (#190).
 * fix: `fs("rfecv")` had the same label as `fs("rfe")`, so both were indistinguishable in `as.data.table(mlr_fselectors)`. Its manual page also instructed to construct it with `fs("rfe")` (#191).
+* fix: `AutoFSelector` ignored the `predict_type` when the final model was fitted, so `$predict()` returned response predictions although e.g. `"prob"` was set. Errors raised while setting the predict type on the final model are not swallowed anymore (#184).
 * fix: `AutoFSelector$train()` did not check the row ids of an instantiated inner resampling for cross-validation and reported a wrong set number for holdout (#197).
 * fix: The `mlr3fselect.svm_rfe` callback accepted support vector machines without a `type` or `kernel` setting, although only `type = "C-classification"` and `kernel = "linear"` are supported. The callback now also errors on multi-class tasks for which the importance scores are not defined (#173).
 * fix: The asynchronous feature selection ignored the `always_included` column role. Columns with this role were excluded from the models instead of being added to every feature subset (#175).

--- a/R/AutoFSelector.R
+++ b/R/AutoFSelector.R
@@ -316,13 +316,10 @@ AutoFSelector = R6Class(
         stopf("Learner '%s' does not support predict type '%s'", self$id, rhs)
       }
 
-      # Catches 'Error: Field/Binding is read-only' bug
-      tryCatch(
-        {
-          self$model$learner$predict_type = rhs
-        },
-        error = function(cond) {}
-      )
+      # the final model only exists after training
+      if (!is.null(self$model$learner)) {
+        self$model$learner$predict_type = rhs
+      }
 
       private$.predict_type = rhs
     },
@@ -399,6 +396,9 @@ AutoFSelector = R6Class(
 
       learner = ia$learner$clone(deep = TRUE)
       task = task$clone()
+
+      # the final model produces the predictions of the auto fselector
+      learner$predict_type = private$.predict_type
 
       # disable timeout to allow train on full data set without time limit
       # timeout during optimization is not affected

--- a/tests/testthat/test_AutoFSelector.R
+++ b/tests/testthat/test_AutoFSelector.R
@@ -336,3 +336,41 @@ test_that("hash and phash are stable and identical", {
   at_2$id = "other"
   expect_false(at_1$hash == at_2$hash)
 })
+
+test_that("predict_type is set on the final model", {
+  at = auto_fselector(
+    fselector = fs("random_search", batch_size = 1),
+    learner = lrn("classif.rpart"),
+    resampling = rsmp("holdout"),
+    measure = msr("classif.ce"),
+    term_evals = 2
+  )
+
+  # setting the predict type before training only changes the auto fselector
+  at$predict_type = "prob"
+  expect_equal(at$predict_type, "prob")
+
+  at$train(tsk("iris"))
+  expect_equal(at$model$learner$predict_type, "prob")
+
+  # setting the predict type after training also changes the final model
+  at$predict_type = "response"
+  expect_equal(at$predict_type, "response")
+  expect_equal(at$model$learner$predict_type, "response")
+
+  expect_error(at$predict_type <- "se", "does not support predict type")
+})
+
+test_that("predict_type is used for the predictions", {
+  at = auto_fselector(
+    fselector = fs("random_search", batch_size = 1),
+    learner = lrn("classif.rpart"),
+    resampling = rsmp("holdout"),
+    measure = msr("classif.ce"),
+    term_evals = 2
+  )
+  at$predict_type = "prob"
+  at$train(tsk("iris"))
+
+  expect_matrix(at$predict(tsk("iris"))$prob)
+})


### PR DESCRIPTION
```r
# Catches 'Error: Field/Binding is read-only' bug
tryCatch({ self$model$learner$predict_type = rhs }, error = function(cond) {})
private$.predict_type = rhs
```

A bare catch-all that discards the condition. If the trained learner rejects the predict type, `private$.predict_type` was still updated and the object was left inconsistent — `afs$predict_type` claims `"prob"` while the wrapped learner still predicts `"response"`, and the failure only surfaces later inside `$predict()`. The `tryCatch()` was only there because `self$model$learner` is `NULL` before training, so that condition is now checked explicitly.

While confirming the fix I found the same inconsistency on the other side: `.train()` fits the final model from `instance_args$learner`, which never sees `private$.predict_type`. Setting `at$predict_type = "prob"` before `$train()` was silently dropped and `at$predict()` returned response predictions, because `.predict()` delegates to `self$model$learner$predict()`. The predict type is now applied to the final model before it is fitted.

Tests cover both directions and the error case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)