### PR TITLE
docs(AutoFSelector): describe what hash and phash cover

### DIFF
--- a/R/AutoFSelector.R
+++ b/R/AutoFSelector.R
@@ -329,6 +329,8 @@ AutoFSelector = R6Class(
 
     #' @field hash (`character(1)`)\cr
     #' Hash (unique identifier) for this object.
+    #' Covers the id, the parameter values, the predict type, the fallback learner, the parallel predict flag,
+    #' the [FSelector], the arguments of the [FSelectInstanceBatchSingleCrit] and the store fselect instance flag.
     hash = function(rhs) {
       assert_ro_binding(rhs)
       calculate_hash(
@@ -345,9 +347,10 @@ AutoFSelector = R6Class(
     },
 
     #' @field phash (`character(1)`)\cr
-    #' Hash (unique identifier) for this partial object,
-    #' excluding some components which are varied systematically during tuning (parameter values)
-    #' or feature selection (feature names).
+    #' Hash (unique identifier) for this partial object.
+    #' The [AutoFSelector] has no components that are varied systematically during tuning or feature selection,
+    #' because the search space is created internally from the task.
+    #' The partial hash is therefore deliberately identical to `$hash`.
     phash = function(rhs) {
       assert_ro_binding(rhs)
       self$hash

--- a/man/AutoFSelector.Rd
+++ b/man/AutoFSelector.Rd
@@ -131,12 +131,15 @@ Stores the currently active predict type, e.g. \code{"response"}.
 Must be an element of \verb{$predict_types}.}
 
     \item{\code{hash}}{(\code{character(1)})\cr
-Hash (unique identifier) for this object.}
+Hash (unique identifier) for this object.
+Covers the id, the parameter values, the predict type, the fallback learner, the parallel predict flag,
+the \link{FSelector}, the arguments of the \link{FSelectInstanceBatchSingleCrit} and the store fselect instance flag.}
 
     \item{\code{phash}}{(\code{character(1)})\cr
-Hash (unique identifier) for this partial object,
-excluding some components which are varied systematically during tuning (parameter values)
-or feature selection (feature names).}
+Hash (unique identifier) for this partial object.
+The \link{AutoFSelector} has no components that are varied systematically during tuning or feature selection,
+because the search space is created internally from the task.
+The partial hash is therefore deliberately identical to \verb{$hash}.}
   }
   \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test_AutoFSelector.R
+++ b/tests/testthat/test_AutoFSelector.R
@@ -319,3 +319,20 @@ test_that("instantiated resampling with foreign row ids is rejected", {
   expect_error(run("cv", folds = 3), "set 1 of inner resampling 'cv' contains row ids")
   expect_error(run("holdout"), "set 1 of inner resampling 'holdout' contains row ids")
 })
+
+test_that("hash and phash are stable and identical", {
+  at_1 = auto_fselector(
+    fselector = fs("random_search", batch_size = 1),
+    learner = lrn("classif.rpart"),
+    resampling = rsmp("holdout"),
+    measure = msr("classif.ce"),
+    term_evals = 2
+  )
+  at_2 = at_1$clone(deep = TRUE)
+
+  expect_equal(at_1$hash, at_2$hash)
+  expect_equal(at_1$phash, at_1$hash)
+
+  at_2$id = "other"
+  expect_false(at_1$hash == at_2$hash)
+})


### PR DESCRIPTION
`$phash` is documented as *"excluding some components which are varied systematically ... (feature names)"* but is implemented as `self$hash`, and the two are confirmed identical.

They are identical on purpose. The `AutoFSelector` builds its search space internally from the task, so unlike `mlr3::Learner` — whose `phash` drops the `param_set$values` that tuning varies — it has no component that is systematically varied from the outside. `mlr3tuning::AutoTuner$phash` does the same thing. So this is a documentation fix, not a behavior change: the field now states that the equality is deliberate, and `$hash` documents which components it covers.

On the related note about `$hash` digesting the raw R6 objects in `self$instance_args`: I checked this before changing anything. Two independently constructed, identically configured `AutoFSelector`s produce the same hash, and the hash is byte-identical across separate R sessions. Since the current value is stable and changing the composition would invalidate every stored hash, I left it as is. A test now pins the stability and the `phash == hash` equality so a future change to either is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)