### PR TITLE
refactor(objective): use the extract_runtime() helper

### DIFF
--- a/R/ObjectiveFSelectBatch.R
+++ b/R/ObjectiveFSelectBatch.R
@@ -105,11 +105,7 @@ ObjectiveFSelectBatch = R6Class(
       lg$debug("Aggregated performance %s", as_short_string(private$.aggregated_performance))
 
       # add runtime to evaluations
-      time = map_dbl(private$.benchmark_result$resample_results$resample_result, function(rr) {
-        sum(map_dbl(get_private(rr)$.data$learner_states(get_private(rr)$.view), function(state) {
-          state$train_time + state$predict_time
-        }))
-      })
+      time = map_dbl(private$.benchmark_result$resample_results$resample_result, extract_runtime)
       set(private$.aggregated_performance, j = "runtime_learners", value = time)
 
       # store benchmark result in archive


### PR DESCRIPTION
`extract_runtime()` (`R/helper.R`) was called only from `ObjectiveFSelectAsync`. `ObjectiveFSelectBatch` open-coded the identical logic, including the same `get_private(rr)$.data$learner_states(get_private(rr)$.view)` reach into mlr3 internals — so the private-API dependency lived in two places instead of one.

The batch objective now calls the helper. No behavior change; the existing objective and archive tests cover the `runtime_learners` column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)