### PR TITLE
refactor(helper): remove the dead paradox compatibility branch

### DIFF
--- a/R/helper.R
+++ b/R/helper.R
@@ -7,12 +7,7 @@ task_to_domain = function(task) {
 measures_to_codomain = function(measures) {
   measures = as_measures(measures)
   domains = map(measures, function(s) {
-    if ("set_id" %in% names(ps())) {
-      # old paradox
-      get("ParamDbl")$new(id = s$id, tags = ifelse(s$minimize, "minimize", "maximize"))
-    } else {
-      p_dbl(tags = ifelse(s$minimize, "minimize", "maximize"))
-    }
+    p_dbl(tags = if (s$minimize) "minimize" else "maximize")
   })
   names(domains) = ids(measures)
   Codomain$new(domains)


### PR DESCRIPTION
```r
domains = map(measures, function(s) {
  if ("set_id" %in% names(ps())) {
    # old paradox
    get("ParamDbl")$new(id = s$id, tags = ifelse(s$minimize, "minimize", "maximize"))
  } else {
    p_dbl(tags = ifelse(s$minimize, "minimize", "maximize"))
  }
})
```

The branch targets paradox < 1.0.0, while `DESCRIPTION` requires `paradox (>= 1.0.0)`, so the `get("ParamDbl")` path is unreachable. The condition also constructed a throwaway `ps()` once *per measure*.

The branch and the `get("ParamDbl")` indirection are removed, and the scalar `ifelse()` — the vectorised form applied to a scalar — becomes `if`/`else`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)