### PR TITLE
style: drop the :: prefix for wholesale imported packages

### DIFF
--- a/R/EnsembleFSResult.R
+++ b/R/EnsembleFSResult.R
@@ -277,7 +277,7 @@ EnsembleFSResult = R6Class(
         }
 
         # Combine results from both objects
-        private$.result = data.table::rbindlist(list(private$.result, result2), fill = FALSE)
+        private$.result = rbindlist(list(private$.result, result2), fill = FALSE)
 
         # Merge benchmark results if available in both objects
         has_bmr = !is.null(self$benchmark_result)
@@ -523,7 +523,7 @@ EnsembleFSResult = R6Class(
         pf = pf[n_features > 0]
 
         # Fit the linear model
-        form = mlr3misc::formulate(lhs = measure_id, rhs = "n_features_inv")
+        form = formulate(lhs = measure_id, rhs = "n_features_inv")
         model = stats::lm(formula = form, data = pf)
 
         # Predict values using the model to create a smooth curve

--- a/R/FSelectorBatchGeneticSearch.R
+++ b/R/FSelectorBatchGeneticSearch.R
@@ -56,7 +56,7 @@ FSelectorBatchGeneticSearch = R6Class(
       }
       n = inst$objective$domain$length
 
-      mlr3misc::invoke(genalg::rbga.bin, size = n, evalFunc = inst$objective_function, .args = pars)
+      invoke(genalg::rbga.bin, size = n, evalFunc = inst$objective_function, .args = pars)
     }
   )
 )

--- a/R/mlr_callbacks.R
+++ b/R/mlr_callbacks.R
@@ -226,18 +226,18 @@ load_callback_internal_tuning = function() {
 
     on_eval_before_archive = function(callback, context) {
       # extract internal tuned values and aggregate folds
-      internal_tuned_values = mlr3misc::map(
+      internal_tuned_values = map(
         context$benchmark_result$resample_results$resample_result,
         function(resample_result) {
-          internal_tuned_values = mlr3misc::transpose_list(mlr3misc::map(
-            mlr3misc::get_private(resample_result)$.data$learner_states(mlr3misc::get_private(resample_result)$.view),
+          internal_tuned_values = transpose_list(map(
+            get_private(resample_result)$.data$learner_states(get_private(resample_result)$.view),
             "internal_tuned_values"
           ))
           callback$state$internal_search_space$aggr_internal_tuned_values(internal_tuned_values)
         }
       )
 
-      data.table::set(context$aggregated_performance, j = "internal_tuned_values", value = list(internal_tuned_values))
+      set(context$aggregated_performance, j = "internal_tuned_values", value = list(internal_tuned_values))
     },
 
     on_optimization_end = function(callback, context) {

--- a/R/mlr_callbacks.R
+++ b/R/mlr_callbacks.R
@@ -226,6 +226,9 @@ load_callback_internal_tuning = function() {
 
     on_eval_before_archive = function(callback, context) {
       # extract internal tuned values and aggregate folds
+      # PRIVATE MLR3 API: `$.data$learner_states()` and `$.view` are private fields of `mlr3::ResampleResult`.
+      # There is no public accessor for the learner states. The layout is stable for the mlr3 versions supported
+      # in DESCRIPTION (>= 1.0.1) and must be re-checked on every mlr3 update.
       internal_tuned_values = map(
         context$benchmark_result$resample_results$resample_result,
         function(resample_result) {

--- a/R/mlr_callbacks.R
+++ b/R/mlr_callbacks.R
@@ -226,9 +226,6 @@ load_callback_internal_tuning = function() {
 
     on_eval_before_archive = function(callback, context) {
       # extract internal tuned values and aggregate folds
-      # PRIVATE MLR3 API: `$.data$learner_states()` and `$.view` are private fields of `mlr3::ResampleResult`.
-      # There is no public accessor for the learner states. The layout is stable for the mlr3 versions supported
-      # in DESCRIPTION (>= 1.0.1) and must be re-checked on every mlr3 update.
       internal_tuned_values = map(
         context$benchmark_result$resample_results$resample_result,
         function(resample_result) {


### PR DESCRIPTION
`mlr3fselect.internal_tuning` used `mlr3misc::map`, `mlr3misc::transpose_list`, `mlr3misc::get_private` and `data.table::set` — all four packages are imported wholesale, and `CLAUDE.md` forbids the prefix. The same callback used a bare `set()` in the next handler, so the file was not even internally consistent.

While there I removed the three remaining code-level occurrences elsewhere, which are the same violation:

* `R/EnsembleFSResult.R:280` — `data.table::rbindlist`
* `R/EnsembleFSResult.R:526` — `mlr3misc::formulate`
* `R/FSelectorBatchGeneticSearch.R:59` — `mlr3misc::invoke` (the `genalg::rbga.bin` prefix stays; `genalg` is only suggested)

The `mlr3misc::` prefixes in `R/reexports.R` are re-export declarations and are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)