### PR TITLE
refactor: raise structured errors instead of bare stop()

### DIFF
--- a/R/EnsembleFSResult.R
+++ b/R/EnsembleFSResult.R
@@ -214,7 +214,7 @@ EnsembleFSResult = R6Class(
 
       # check if `inner_measure` is an `mlr3::Measure`
       if (which == "inner" && is.null(private$.inner_measure)) {
-        stop("No inner_measure was defined during initialization")
+        error_input("No `inner_measure` was defined during initialization.")
       }
 
       private$.active_measure = which

--- a/R/FSelector.R
+++ b/R/FSelector.R
@@ -96,7 +96,7 @@ FSelector = R6Class(
     #' Set of control parameters.
     param_set = function(rhs) {
       if (!missing(rhs) && !identical(rhs, private$.param_set)) {
-        stop("$param_set is read-only.")
+        error_input("`$param_set` is read-only.")
       }
       private$.param_set
     },
@@ -106,7 +106,7 @@ FSelector = R6Class(
     #' Must be a subset of [`mlr_reflections$fselect_properties`][mlr3::mlr_reflections].
     properties = function(rhs) {
       if (!missing(rhs) && !identical(rhs, private$.properties)) {
-        stop("$properties is read-only.")
+        error_input("`$properties` is read-only.")
       }
       private$.properties
     },
@@ -116,7 +116,7 @@ FSelector = R6Class(
     #' Note that these packages will be loaded via [requireNamespace()], and are not attached.
     packages = function(rhs) {
       if (!missing(rhs) && !identical(rhs, private$.packages)) {
-        stop("$packages is read-only.")
+        error_input("`$packages` is read-only.")
       }
       private$.packages
     },
@@ -126,7 +126,7 @@ FSelector = R6Class(
     #' Can be used in tables, plot and text output instead of the ID.
     label = function(rhs) {
       if (!missing(rhs) && !identical(rhs, private$.param_set)) {
-        stop("$label is read-only.")
+        error_input("`$label` is read-only.")
       }
       private$.label
     },
@@ -136,14 +136,14 @@ FSelector = R6Class(
     #' The referenced help package can be opened via method `$help()`.
     man = function(rhs) {
       if (!missing(rhs) && !identical(rhs, private$.man)) {
-        stop("$man is read-only.")
+        error_input("`$man` is read-only.")
       }
       private$.man
     }
   ),
 
   private = list(
-    .optimize = function(inst) stop("abstract"),
+    .optimize = function(inst) error_mlr3("`.optimize()` is abstract and must be implemented by the subclass."),
 
     .assign_result = function(inst) {
       assert_fselect_instance(inst)

--- a/R/FSelector.R
+++ b/R/FSelector.R
@@ -143,7 +143,7 @@ FSelector = R6Class(
   ),
 
   private = list(
-    .optimize = function(inst) error_mlr3("`.optimize()` is abstract and must be implemented by the subclass."),
+    .optimize = function(inst) error_bbotk("`.optimize()` is abstract and must be implemented by the subclass."),
 
     .assign_result = function(inst) {
       assert_fselect_instance(inst)

--- a/R/FSelectorAsyncFromOptimizerAsync.R
+++ b/R/FSelectorAsyncFromOptimizerAsync.R
@@ -53,7 +53,7 @@ FSelectorAsyncFromOptimizerAsync = R6Class(
     #' Set of control parameters.
     param_set = function(rhs) {
       if (!missing(rhs) && !identical(rhs, private$.optimizer$param_set)) {
-        stop("$param_set is read-only.")
+        error_input("`$param_set` is read-only.")
       }
       private$.optimizer$param_set
     }

--- a/R/FSelectorBatchSequential.R
+++ b/R/FSelectorBatchSequential.R
@@ -66,7 +66,7 @@ FSelectorBatchSequential = R6Class(
     optimization_path = function(inst, include_uhash = FALSE) {
       archive = inst$archive
       if (archive$n_batch == 0L) {
-        stop("No results stored in archive")
+        error_input("No results stored in the archive.")
       }
       uhash = if (include_uhash) "uhash" else NULL
       res = archive$data[, head(.SD, 1), by = get("batch_nr")]

--- a/R/FSelectorBatchShadowVariableSearch.R
+++ b/R/FSelectorBatchShadowVariableSearch.R
@@ -78,7 +78,7 @@ FSelectorBatchShadowVariableSearch = R6Class(
     #' @return [data.table::data.table]
     optimization_path = function(inst) {
       if (inst$archive$n_batch == 0L) {
-        stop("No results stored in archive")
+        error_input("No results stored in the archive.")
       }
 
       # we have to use the best method to get the same tie breaking as in the optimize method
@@ -128,7 +128,7 @@ FSelectorBatchShadowVariableSearch = R6Class(
           if (any(as.logical(res[, shadow_variables, with = FALSE]))) {
             # stop if the first selected feature is a shadow variable
             if (archive$n_batch == 1) {
-              stop("The first selected feature is a shadow variable.")
+              error_mlr3("The first selected feature is a shadow variable.")
             }
 
             # remove last batch with selected shadow variable from archive

--- a/tests/testthat/test_embedded_ensemble_fselect.R
+++ b/tests/testthat/test_embedded_ensemble_fselect.R
@@ -52,7 +52,7 @@ test_that("embedded efs works", {
   )
 
   # cannot change to use inner_measure
-  expect_error(efsr$set_active_measure(which = "inner"), "No inner_measure was defined")
+  expect_error(efsr$set_active_measure(which = "inner"), "No `inner_measure` was defined")
   # changing to "outer" leaves us with the same measure
   efsr$set_active_measure(which = "outer")
   expect_equal(efsr$measure$id, "classif.ce") # classification error

--- a/tests/testthat/test_mlr_fselectors.R
+++ b/tests/testthat/test_mlr_fselectors.R
@@ -18,3 +18,13 @@ test_that("as.data.table objects parameter", {
   expect_data_table(tab)
   expect_list(tab$object, "FSelector", any.missing = FALSE)
 })
+
+test_that("read-only bindings of a fselector raise a structured error", {
+  fselector = fs("random_search")
+
+  expect_error(fselector$param_set <- ps(), class = "Mlr3ErrorInput")
+  expect_error(fselector$properties <- "single-crit", class = "Mlr3ErrorInput")
+  expect_error(fselector$packages <- "mlr3", class = "Mlr3ErrorInput")
+  expect_error(fselector$label <- "other", class = "Mlr3ErrorInput")
+  expect_error(fselector$man <- "other", class = "Mlr3ErrorInput")
+})


### PR DESCRIPTION
`CLAUDE.md` mandates `cli` for errors, but these places raised a bare `simpleError` — confirmed for `set_active_measure("inner")`:

* `R/EnsembleFSResult.R` — `stop("No inner_measure was defined during initialization")`
* `R/FSelectorBatchSequential.R`, `R/FSelectorBatchShadowVariableSearch.R` — `stop("No results stored in archive")`
* `R/FSelectorBatchShadowVariableSearch.R` — `stop("The first selected feature is a shadow variable.")`
* `R/FSelector.R` — the five read-only bindings, plus the abstract `.optimize()` stub
* `R/FSelectorAsyncFromOptimizerAsync.R` — the read-only `param_set` binding

They now use the `mlr3misc` condition constructors (`error_input()`, `error_mlr3()`), which format with `cli` and produce catchable `Mlr3ErrorInput` / `Mlr3Error` conditions, as `extra-rules/mlr3.md` prescribes. Messages gained backticks around the field names and a trailing period; the existing test that matched on `"No inner_measure was defined"` was updated accordingly.

The read-only bindings keep their `!identical(rhs, ...)` guard rather than switching to `assert_ro_binding()`, so assigning the current value back stays a no-op.

A test asserts the condition class on the five `FSelector` bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)