### PR TITLE
fix(zzz): append the reflections with unique()

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,20 +10,25 @@
 #' @importFrom stats sd
 "_PACKAGE"
 
-.onLoad = function(libname, pkgname) {
-  # nocov start
-  utils::globalVariables(c("super", "self", "n_features", "errors"))
-
-  # reflections
+# Registers the properties, column roles and packages of mlr3fselect in the reflections of bbotk and mlr3.
+# All entries are appended with `unique()` because the function runs again on every `devtools::load_all()`.
+register_reflections = function() {
   x = utils::getFromNamespace("bbotk_reflections", ns = "bbotk")
-  x$optimizer_properties = c(x$optimizer_properties, "requires_model")
+  x$optimizer_properties = unique(c(x$optimizer_properties, "requires_model"))
 
   x = utils::getFromNamespace("mlr_reflections", ns = "mlr3")
   walk(names(x$task_col_roles), function(task_type) {
     x$task_col_roles[[task_type]] = unique(c(x$task_col_roles[[task_type]], "always_included"))
   })
 
-  x$loaded_packages = c(x$loaded_packages, "mlr3fselect")
+  x$loaded_packages = unique(c(x$loaded_packages, "mlr3fselect"))
+}
+
+.onLoad = function(libname, pkgname) {
+  # nocov start
+  utils::globalVariables(c("super", "self", "n_features", "errors"))
+
+  register_reflections()
 
   # callbacks
   x = utils::getFromNamespace("mlr_callbacks", ns = "mlr3misc")

--- a/tests/testthat/test_mlr_fselectors.R
+++ b/tests/testthat/test_mlr_fselectors.R
@@ -18,3 +18,17 @@ test_that("as.data.table objects parameter", {
   expect_data_table(tab)
   expect_list(tab$object, "FSelector", any.missing = FALSE)
 })
+
+test_that("reloading the package does not duplicate reflections", {
+  bbotk_reflections = utils::getFromNamespace("bbotk_reflections", ns = "bbotk")
+  mlr_reflections = utils::getFromNamespace("mlr_reflections", ns = "mlr3")
+
+  register_reflections()
+  register_reflections()
+
+  expect_equal(sum(bbotk_reflections$optimizer_properties == "requires_model"), 1L)
+  expect_equal(sum(mlr_reflections$loaded_packages == "mlr3fselect"), 1L)
+  walk(mlr_reflections$task_col_roles, function(col_roles) {
+    expect_equal(sum(col_roles == "always_included"), 1L)
+  })
+})


### PR DESCRIPTION
```r
x$optimizer_properties = c(x$optimizer_properties, "requires_model")
x$loaded_packages = c(x$loaded_packages, "mlr3fselect")
```

Both append without `unique()`, so repeated `devtools::load_all()` accumulates duplicates. The `task_col_roles` loop two lines below already uses `unique()` — that one was fixed in 1.1.0 and these two were missed.

The registration is extracted into `register_reflections()` so the test can call it twice and assert that each entry appears exactly once. The test errors on the previous implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)