### PR TITLE
refactor(faggregate): drop the conjunct that is always true

### DIFF
--- a/R/faggregate.R
+++ b/R/faggregate.R
@@ -72,7 +72,8 @@ fscore_single_measure = function(prediction, measure) {
   # convert pdata to regular prediction
   prediction = as_prediction(prediction, check = FALSE)
 
-  if (is.null(prediction) && length(measure$predict_sets)) {
+  # the early return above guarantees that the measure has predict sets
+  if (is.null(prediction)) {
     return(NaN)
   }
 


### PR DESCRIPTION
```r
if (is.null(prediction) && length(measure$predict_sets)) {
```

`fscore_single_measure()` returns early at the top when `!length(measure$predict_sets)`, so the second conjunct is guaranteed true by the time control reaches this line. Dropped, with a comment naming the guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)